### PR TITLE
Fix AltStore Source by removing extraneous comma

### DIFF
--- a/altstore/odysseysource.json
+++ b/altstore/odysseysource.json
@@ -53,7 +53,7 @@
       "url": "https://altstore.theodyssey.dev",
       "date": "2020-08-12T12:59:00-07:00",
       "notify": false
-    },
+    }
   ],
   "userInfo": {}
 }


### PR DESCRIPTION
Real simple fix. The AltStore Source will not work with AltStore unless the JSON is valid.