### PR TITLE
Make identifier different so it displays correctly

### DIFF
--- a/altstore/odysseysource.json
+++ b/altstore/odysseysource.json
@@ -27,7 +27,7 @@
   "news": [
     {
       "title": "Odyssey 1.2 now available!",
-      "identifier": "odyssey-x-altstore",
+      "identifier": "odyssey-1.2-available",
       "caption": "Supports iOS 13.0-13.7",
       "tintColor": "D287F4",
       "imageURL": "https://theodyssey.dev/assets/images/meta.png",


### PR DESCRIPTION
Each news article needs to have a unique identifier for AltStore to correctly display them both. In its current state, it will only show one at a time and will sometimes switch between them.

For future reference, the AltStore Source documentation can be found here: https://github.com/noah978/AltStore-Docs